### PR TITLE
Update task-1-tests.js row 86 throws error - OK by definition, wrong for the test

### DIFF
--- a/Sample exam/tests/task-1-tests.js
+++ b/Sample exam/tests/task-1-tests.js
@@ -83,7 +83,7 @@ describe('Sample exam tests', function() {
         expect(player.getPlaylistById(playlist.id)).to.be["null"];
         results = [];
         for (i = j = 0; j <= 5; i = ++j) {
-          results.push(player.addPlaylist(name + i));
+          results.push(player.addPlaylist(result.getPlaylist(name + i)));
         }
         return results;
       });


### PR DESCRIPTION
function addPlaylist(playlist) should accept only objects of type Playlist by definition, otherwise it should throw error by definition.
On row 86 a string was passed as parameter of addPlaylist()
results.push(player.addPlaylist(name + i));
 so it threw error which was correct by definition but not is not considered as correct for this test.
result.getPlaylist(name + i) is proposed as a parameter in order to create a list first.